### PR TITLE
Add rule-based dentist SOAP note transcription agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.env
+.venv

--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
-# bedrock
+# Bedrock Dentist SOAP Agent
+
+This repository contains a simple rule-based "meeting transcription agent" for
+dental SOAP note charting. The agent expects a text transcript of a
+conversation (for example, a short stand-up between a dentist and a dental
+assistant while treating a patient) and produces a structured Subjective,
+Objective, Assessment, and Plan summary.
+
+## Quick start
+
+1. Create and activate a Python 3.9+ virtual environment.
+2. Install the project in editable mode with the optional CLI extras:
+
+   ```bash
+   pip install -e .[cli]
+   ```
+
+3. Run the agent against one of the sample transcripts:
+
+   ```bash
+   python -m dentist_agent.transcription_agent transcripts/sample_transcript.txt
+   ```
+
+The agent will print the generated SOAP note to standard output as formatted
+Markdown.
+
+## Project layout
+
+```
+├── dentist_agent/
+│   ├── __init__.py
+│   └── transcription_agent.py
+├── transcripts/
+│   └── sample_transcript.txt
+├── tests/
+│   └── test_transcription_agent.py
+├── README.md
+└── pyproject.toml
+```
+
+* `dentist_agent/transcription_agent.py` implements the rule-based
+  summarisation logic.
+* `transcripts/sample_transcript.txt` provides a short example conversation.
+* `tests/test_transcription_agent.py` exercises the core extraction helper.
+
+Run the automated checks with:
+
+```bash
+python -m pytest
+```

--- a/dentist_agent/__init__.py
+++ b/dentist_agent/__init__.py
@@ -1,0 +1,3 @@
+"""Dentist meeting transcription agent package."""
+
+from .transcription_agent import DentistSOAPAgent, SOAPNote  # noqa: F401

--- a/dentist_agent/transcription_agent.py
+++ b/dentist_agent/transcription_agent.py
@@ -1,0 +1,267 @@
+"""Rule-based agent for generating dentist SOAP notes from meeting transcripts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence
+
+
+@dataclass
+class Utterance:
+    """Simple representation of a line within a meeting transcript."""
+
+    speaker: str
+    text: str
+
+    def normalized_speaker(self) -> str:
+        """Return a lowercase speaker identifier without punctuation."""
+
+        return re.sub(r"[^a-z0-9]+", " ", self.speaker.lower()).strip()
+
+
+@dataclass
+class SOAPNote:
+    """Structured representation of a SOAP note."""
+
+    patient_name: Optional[str] = None
+    subjective: List[str] = field(default_factory=list)
+    objective: List[str] = field(default_factory=list)
+    assessment: List[str] = field(default_factory=list)
+    plan: List[str] = field(default_factory=list)
+
+    def add(self, section: str, statement: str) -> None:
+        """Append a statement to a section, avoiding duplicates."""
+
+        store = getattr(self, section)
+        statement = statement.strip()
+        if statement and statement not in store:
+            store.append(statement)
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise the note as a dictionary."""
+
+        return {
+            "patient_name": self.patient_name,
+            "subjective": self.subjective,
+            "objective": self.objective,
+            "assessment": self.assessment,
+            "plan": self.plan,
+        }
+
+    def to_markdown(self) -> str:
+        """Render the note as Markdown."""
+
+        lines: List[str] = ["# SOAP Note"]
+        if self.patient_name:
+            lines.append(f"**Patient:** {self.patient_name}")
+            lines.append("")
+        for header, values in (
+            ("Subjective", self.subjective),
+            ("Objective", self.objective),
+            ("Assessment", self.assessment),
+            ("Plan", self.plan),
+        ):
+            lines.append(f"## {header}")
+            if values:
+                for item in values:
+                    lines.append(f"- {item}")
+            else:
+                lines.append("- _No information captured._")
+            lines.append("")
+        return "\n".join(lines).strip()
+
+
+class DentistSOAPAgent:
+    """Heuristic agent that maps transcript lines into SOAP sections."""
+
+    patient_aliases: Sequence[str] = (
+        "patient",
+        "pt",
+        "client",
+    )
+    clinician_aliases: Sequence[str] = (
+        "dentist",
+        "doctor",
+        "dr",
+        "hygienist",
+        "assistant",
+        "da",
+        "rdh",
+    )
+
+    plan_keywords: Sequence[str] = (
+        "schedule",
+        "follow up",
+        "follow-up",
+        "plan",
+        "next visit",
+        "next time",
+        "recommend",
+        "will ",
+        "prescribe",
+        "apply",
+        "perform",
+    )
+    assessment_keywords: Sequence[str] = (
+        "assessment",
+        "diagnos",
+        "decay",
+        "caries",
+        "periodontal",
+        "gingivitis",
+        "condition",
+        "issue",
+        "finding",
+        "lesion",
+        "inflam",
+    )
+
+    objective_keywords: Sequence[str] = (
+        "radiograph",
+        "x-ray",
+        "probe",
+        "measurement",
+        "score",
+        "observ",
+        "vitals",
+        "chart",
+        "pocket",
+        "plaque",
+        "calculus",
+    )
+
+    def parse_transcript(self, transcript: str) -> List[Utterance]:
+        """Parse a raw transcript into individual utterances."""
+
+        utterances: List[Utterance] = []
+        current: Optional[Utterance] = None
+        speaker_pattern = re.compile(r"^\s*([^:]+):\s*(.*)$")
+
+        for line in transcript.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            match = speaker_pattern.match(stripped)
+            if match:
+                if current is not None:
+                    utterances.append(current)
+                speaker, text = match.groups()
+                current = Utterance(speaker=speaker.strip(), text=text.strip())
+            elif current is not None:
+                current.text += " " + stripped
+        if current is not None:
+            utterances.append(current)
+        return utterances
+
+    def _is_patient(self, utterance: Utterance) -> bool:
+        speaker = utterance.normalized_speaker()
+        for alias in self.patient_aliases:
+            if speaker.startswith(alias):
+                return True
+        return False
+
+    def _is_clinician(self, utterance: Utterance) -> bool:
+        speaker = utterance.normalized_speaker()
+        for alias in self.clinician_aliases:
+            if alias in speaker.split():
+                return True
+        return False
+
+    def guess_patient_name(self, utterances: Iterable[Utterance]) -> Optional[str]:
+        """Attempt to infer the patient name from the transcript."""
+
+        for utterance in utterances:
+            # Look for "Patient <Name>" patterns in the speaker field.
+            match = re.match(r"patient\s+([A-Z][\w'-]*(?:\s+[A-Z][\w'-]*)*)", utterance.speaker, re.I)
+            if match:
+                return match.group(1)
+            # Scan the text for phrases such as "patient Mary Johnson".
+            match = re.search(
+                r"patient(?:'s)?\s+(?:name\s+is\s+)?([A-Z][\w'-]*(?:\s+[A-Z][\w'-]*)*)",
+                utterance.text,
+                re.I,
+            )
+            if match:
+                return match.group(1)
+        return None
+
+    def classify(self, utterance: Utterance) -> str:
+        """Classify an utterance into a SOAP section."""
+
+        text_lower = utterance.text.lower()
+        if self._is_patient(utterance):
+            return "subjective"
+        if any(keyword in text_lower for keyword in self.plan_keywords):
+            return "plan"
+        if any(keyword in text_lower for keyword in self.assessment_keywords):
+            return "assessment"
+        if self._is_clinician(utterance) or any(
+            keyword in text_lower for keyword in self.objective_keywords
+        ):
+            return "objective"
+        # Default to subjective if we cannot categorise.
+        return "subjective"
+
+    def generate_soap_note(
+        self, transcript: str, *, patient_name: Optional[str] = None
+    ) -> SOAPNote:
+        """Generate a SOAP note from a transcript string."""
+
+        utterances = self.parse_transcript(transcript)
+        note = SOAPNote(patient_name=patient_name or self.guess_patient_name(utterances))
+        for utterance in utterances:
+            section = self.classify(utterance)
+            note.add(section, utterance.text)
+        return note
+
+
+def _load_transcript(path: Path) -> str:
+    if not path.exists():
+        raise FileNotFoundError(f"Transcript file not found: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate a dentist SOAP note from a meeting transcript.",
+    )
+    parser.add_argument(
+        "transcript_path",
+        type=Path,
+        help="Path to the transcript text file (Speaker: text per line).",
+    )
+    parser.add_argument(
+        "--patient",
+        type=str,
+        default=None,
+        help="Override the detected patient name.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "json"),
+        default="markdown",
+        help="Output format for the SOAP note (default: markdown).",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    transcript = _load_transcript(args.transcript_path)
+    agent = DentistSOAPAgent()
+    note = agent.generate_soap_note(transcript, patient_name=args.patient)
+
+    if args.format == "json":
+        print(json.dumps(note.to_dict(), indent=2))
+    else:
+        print(note.to_markdown())
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dentist-soap-agent"
+version = "0.1.0"
+description = "Simple rule-based meeting transcription agent for dentist SOAP notes"
+authors = [{name = "Bedrock AI"}]
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = []
+
+[project.optional-dependencies]
+cli = []
+
+[project.urls]
+Homepage = "https://example.com/dentist-soap-agent"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/test_transcription_agent.py
+++ b/tests/test_transcription_agent.py
@@ -1,0 +1,45 @@
+import textwrap
+
+from dentist_agent.transcription_agent import DentistSOAPAgent
+
+
+def test_generate_soap_note_basic_classification():
+    transcript = textwrap.dedent(
+        """
+        Patient Jane Doe: I'm having throbbing pain on the lower right molar.
+        Dentist Dr. Lee: Observed caries on tooth #31 with mild inflammation.
+        Assistant Maya: I'll schedule Jane for a composite filling and provide post-op instructions.
+        """
+    ).strip()
+    agent = DentistSOAPAgent()
+
+    note = agent.generate_soap_note(transcript)
+
+    assert note.patient_name == "Jane Doe"
+    assert note.subjective == ["I'm having throbbing pain on the lower right molar."]
+    assert note.assessment == ["Observed caries on tooth #31 with mild inflammation."]
+    assert note.plan == [
+        "I'll schedule Jane for a composite filling and provide post-op instructions."
+    ]
+    # Objective should remain empty for this short example.
+    assert note.objective == []
+
+
+def test_parse_transcript_handles_multiline_entries():
+    transcript = textwrap.dedent(
+        """
+        Dentist: First line of observation
+            continuing on a second line.
+        Patient: Thank you doctor.
+        """
+    ).strip()
+    agent = DentistSOAPAgent()
+
+    utterances = agent.parse_transcript(transcript)
+
+    assert len(utterances) == 2
+    assert utterances[0].speaker == "Dentist"
+    assert (
+        utterances[0].text
+        == "First line of observation continuing on a second line."
+    )

--- a/transcripts/sample_transcript.txt
+++ b/transcripts/sample_transcript.txt
@@ -1,0 +1,7 @@
+Dentist Dr. Smith: Team, we're reviewing Mary Johnson today for her six-month checkup.
+Patient Mary Johnson: I've been feeling a sharp twinge on the upper left when I drink cold water.
+Assistant Kelly: Prophy completed. Light plaque on the molars, bleeding score 2/6.
+Hygienist Alex: Probed pockets at 3-4 mm, noted slight inflammation near tooth #14.
+Dentist Dr. Smith: Radiographs show early caries on tooth #14 with no pulpal involvement.
+Dentist Dr. Smith: We'll place a resin filling next visit and apply fluoride varnish today.
+Assistant Kelly: I'll schedule Mary for a 45-minute filling appointment next Tuesday.


### PR DESCRIPTION
## Summary
- implement a rule-based `DentistSOAPAgent` to convert meeting transcripts into SOAP notes
- expose a CLI entry point, sample transcript, and packaging metadata for distribution
- add unit tests covering classification and transcript parsing behaviour

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb778561288320a88df19b50d55422